### PR TITLE
CLOUDP-103046: Always parse TLV regardless of config

### DIFF
--- a/source/extensions/filters/listener/proxy_protocol/BUILD
+++ b/source/extensions/filters/listener/proxy_protocol/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
         "//source/common/api:os_sys_calls_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:empty_string",
+        "//source/common/common:hex_lib",
         "//source/common/common:minimal_logger_lib",
         "//source/common/common:safe_memcpy_lib",
         "//source/common/common:utility_lib",

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -17,6 +17,7 @@
 #include "source/common/common/assert.h"
 #include "source/common/common/empty_string.h"
 #include "source/common/common/fmt.h"
+#include "source/common/common/hex.h"
 #include "source/common/common/safe_memcpy.h"
 #include "source/common/common/utility.h"
 #include "source/common/network/address_impl.h"
@@ -114,6 +115,14 @@ ReadOrParseState Filter::onReadWorker() {
   if (proxy_protocol_header_.has_value() &&
       !cb_->filterState().hasData<Network::ProxyProtocolFilterState>(
           Network::ProxyProtocolFilterState::key())) {
+    if (!proxy_protocol_header_.value().local_command_) {
+      ENVOY_LOG(trace,
+                fmt::format("parsed proxy protocol header, length: {}, buffer: {}, "
+                            "TLV length: {}, TLV buffer: {}",
+                            buf_off_,
+                            Envoy::Hex::encode(reinterpret_cast<uint8_t*>(&buf_), buf_off_),
+                            buf_tlv_off_, Envoy::Hex::encode(buf_tlv_.data(), buf_tlv_off_)));
+    }
     cb_->filterState().setData(
         Network::ProxyProtocolFilterState::key(),
         std::make_unique<Network::ProxyProtocolFilterState>(Network::ProxyProtocolData{

--- a/source/extensions/transport_sockets/proxy_protocol/BUILD
+++ b/source/extensions/transport_sockets/proxy_protocol/BUILD
@@ -31,6 +31,7 @@ envoy_cc_library(
         "//envoy/network:connection_interface",
         "//envoy/network:transport_socket_interface",
         "//source/common/buffer:buffer_lib",
+        "//source/common/common:hex_lib",
         "//source/common/network:address_lib",
         "//source/extensions/common/proxy_protocol:proxy_protocol_header_lib",
         "//source/extensions/transport_sockets/common:passthrough_lib",

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
@@ -6,6 +6,7 @@
 #include "envoy/network/transport_socket.h"
 
 #include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/hex.h"
 #include "source/common/network/address_impl.h"
 #include "source/extensions/common/proxy_protocol/proxy_protocol_header.h"
 
@@ -64,6 +65,13 @@ void UpstreamProxyProtocolSocket::generateHeaderV1() {
   Common::ProxyProtocol::generateV1Header(*src_addr->ip(), *dst_addr->ip(), header_buffer_);
 }
 
+namespace {
+std::string toHex(const Buffer::Instance& buffer) {
+  std::string bufferStr = buffer.toString();
+  return Hex::encode(reinterpret_cast<uint8_t*>(bufferStr.data()), bufferStr.length());
+}
+} // namespace
+
 void UpstreamProxyProtocolSocket::generateHeaderV2() {
   if (!options_ || !options_->proxyProtocolOptions().has_value()) {
     Common::ProxyProtocol::generateV2LocalHeader(header_buffer_);
@@ -71,6 +79,8 @@ void UpstreamProxyProtocolSocket::generateHeaderV2() {
     const auto options = options_->proxyProtocolOptions().value();
     Common::ProxyProtocol::generateV2Header(options, header_buffer_);
   }
+  ENVOY_LOG(trace, fmt::format("generated proxy protocol v2 header, length: {}, buffer: {}",
+                               header_buffer_.length(), toHex(header_buffer_)));
 }
 
 Network::IoResult UpstreamProxyProtocolSocket::writeHeader() {


### PR DESCRIPTION
We won't specify `rules` subsection in the Envoy config, so that the existing code skipped parsing TLV. 

Here's the RPM patch build: https://spruce.mongodb.com/version/62842ea19ccd4e704c213e61/changes?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC