### PR TITLE
CLOUDP-152133 Remove prefix 'archive' in the tarball hierarchy and make the tarball public

### DIFF
--- a/evergreen/archive-evergreen-rhel7-amd64.sh
+++ b/evergreen/archive-evergreen-rhel7-amd64.sh
@@ -18,10 +18,12 @@ cd -
 # working directory to "ARCHIVE_PATH" is a workaround.
 ARCHIVE_PATH=archive
 # Example archive file name: envoy-serverless-1.21.3-4-gdbdcfa34cf.rhel7.amd64.tar.gz
-ARCHIVE_DIR=$ARCHIVE_PATH/envoy-serverless-${VERSION}.rhel7.amd64
-mkdir -p ${ARCHIVE_DIR}
+ARCHIVE_DIR=envoy-serverless-${VERSION}.rhel7.amd64
+mkdir -p ${ARCHIVE_PATH}/${ARCHIVE_DIR}
+
 # Only include the envoy binary and the hot-restarter. The start script and the static config should
 # be prepared by the agent.
-cp build/execroot/envoy/bazel-out/k8-opt/bin/source/exe/envoy-static ${ARCHIVE_DIR}/envoy-serverless
-cp ${SRCDIR}/restarter/hot-restarter.py ${ARCHIVE_DIR}
+cp build/execroot/envoy/bazel-out/k8-opt/bin/source/exe/envoy-static ${ARCHIVE_PATH}/${ARCHIVE_DIR}/envoy-serverless
+cp ${SRCDIR}/restarter/hot-restarter.py ${ARCHIVE_PATH}/${ARCHIVE_DIR}/
+cd ${ARCHIVE_PATH}
 tar -zcvf ${ARCHIVE_DIR}.tar.gz ${ARCHIVE_DIR}

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -84,7 +84,7 @@ functions:
           aws s3 ls s3://$BUCKET/build/${build_id}/  \
             | awk '{print $NF}'  \
             | grep "envoy-serverless-.*\.tar\.gz"  \
-            | xargs -I{} -n1 aws s3 cp s3://$BUCKET/build/${build_id}/{} s3://$BUCKET/tarballs/
+            | xargs -I{} -n1 aws s3 cp s3://$BUCKET/build/${build_id}/{} s3://$BUCKET/tarballs/ --acl public-read
 
 buildvariants:
 - name: centos7


### PR DESCRIPTION
Found two minor issues when getting the tarballs ready for Automation team. Sorry about them.

https://jira.mongodb.org/browse/CLOUDP-152133

- Remove prefix 'archive' in the tarball hierarchy
- Make the S3 copied tarball public

Evergreen: https://spruce.mongodb.com/version/63b65fb157e85a0faa97ad98/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

The generated tarball is at https://s3.amazonaws.com/mongodb-mms-build-envoy-serverless/tarballs/envoy-serverless-1.21.3-5-gdb38f6a8a2-dirty.rhel7.amd64.tar.gz