### PR TITLE
CLOUDP-152702: Update Envoy Serverless --version to reflect the change after the base Envoy version

### DIFF
--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -40,3 +40,7 @@ git diff-index --quiet HEAD -- || {
 }
 echo "BUILD_SCM_STATUS ${tree_status}"
 echo "STABLE_BUILD_SCM_STATUS ${tree_status}"
+
+# Generate a build version number to label built binaries in the format specified in evergreen/archive-evergreen-rhel7-amd64.sh
+git_version_number=$(git describe --tags --dirty --always --match 'v[0-9]*' | cut -c 2-)
+echo "GIT_VERSION_NUMBER ${git_version_number}"

--- a/source/common/version/BUILD
+++ b/source/common/version/BUILD
@@ -62,8 +62,8 @@ envoy_cc_library(
     name = "version_includes",
     hdrs = [
         "version.h",
+        ":generate_git_version_number",
         ":generate_version_number",
-        ":generate_git_version_number"
     ],
     deps = [
         "//source/common/singleton:const_singleton",

--- a/source/common/version/BUILD
+++ b/source/common/version/BUILD
@@ -18,6 +18,21 @@ genrule(
     visibility = ["//visibility:private"],
 )
 
+# This genrule generates a header file linking GIT_VERSION_NUMBER to version.h for labeling built binaries using the workspace status command output.
+genrule(
+    name = "generate_git_version_number",
+    outs = ["git_version_number.h"],
+    cmd = """
+      grep GIT_VERSION_NUMBER bazel-out/volatile-status.txt \\
+    | sed 's/^GIT_VERSION_NUMBER //' \\
+    | tr -d '\\n' \\
+    | xargs -I{} echo "#define GIT_VERSION_NUMBER \\"{}\\"" \\
+    > $@
+    """,
+    stamp = 1,
+    visibility = ["//visibility:private"],
+)
+
 genrule(
     name = "generate_api_version_number",
     srcs = ["//:API_VERSION"],
@@ -48,6 +63,7 @@ envoy_cc_library(
     hdrs = [
         "version.h",
         ":generate_version_number",
+        ":generate_git_version_number"
     ],
     deps = [
         "//source/common/singleton:const_singleton",

--- a/source/common/version/version.cc
+++ b/source/common/version/version.cc
@@ -26,7 +26,7 @@ const std::string& VersionInfo::revisionStatus() {
 
 const std::string& VersionInfo::version() {
   CONSTRUCT_ON_FIRST_USE(std::string,
-                         fmt::format("{}/{}/{}/{}/{}", revision(), BUILD_VERSION_NUMBER,
+                         fmt::format("{}/{}/{}/{}/{}", revision(), GIT_VERSION_NUMBER,
                                      revisionStatus(), buildType(), sslVersion()));
 }
 

--- a/source/common/version/version.cc
+++ b/source/common/version/version.cc
@@ -25,9 +25,8 @@ const std::string& VersionInfo::revisionStatus() {
 }
 
 const std::string& VersionInfo::version() {
-  CONSTRUCT_ON_FIRST_USE(std::string,
-                         fmt::format("{}/{}/{}/{}/{}", revision(), GIT_VERSION_NUMBER,
-                                     revisionStatus(), buildType(), sslVersion()));
+  CONSTRUCT_ON_FIRST_USE(std::string, fmt::format("{}/{}/{}/{}/{}", revision(), GIT_VERSION_NUMBER,
+                                                  revisionStatus(), buildType(), sslVersion()));
 }
 
 const envoy::config::core::v3::BuildVersion& VersionInfo::buildVersion() {

--- a/source/common/version/version.h
+++ b/source/common/version/version.h
@@ -6,6 +6,7 @@
 
 #include "source/common/singleton/const_singleton.h"
 #include "source/common/version/version_number.h"
+#include "source/common/version/git_version_number.h"
 
 namespace Envoy {
 

--- a/source/common/version/version.h
+++ b/source/common/version/version.h
@@ -5,8 +5,8 @@
 #include "envoy/config/core/v3/base.pb.h"
 
 #include "source/common/singleton/const_singleton.h"
-#include "source/common/version/version_number.h"
 #include "source/common/version/git_version_number.h"
+#include "source/common/version/version_number.h"
 
 namespace Envoy {
 

--- a/test/exe/version_out_test.sh
+++ b/test/exe/version_out_test.sh
@@ -26,3 +26,13 @@ if [[ "${VERSION}" != "${EXPECTED}" ]]; then
   echo "Version mismatch, got: ${VERSION}, expected: ${EXPECTED}".
   exit 1
 fi
+
+LABEL=$(${ENVOY_BIN} --version | \
+  sed -n -E "s/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-g([0-9a-f]{10})(-dirty)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\4/p")
+
+EXPECTED="$(cat "${TEST_SRCDIR}/envoy/bazel/raw_build_id.ldscript" | head -c 10)"
+
+if [[ "${LABEL}" != "${EXPECTED}" ]]; then
+  echo "Label mismatch, got: ${LABEL}, expected: ${EXPECTED}".
+  exit 1
+fi

--- a/test/exe/version_out_test.sh
+++ b/test/exe/version_out_test.sh
@@ -8,7 +8,7 @@ export LC_ALL=C
 ENVOY_BIN="${TEST_SRCDIR}/envoy/source/exe/envoy-static"
 
 COMMIT=$(${ENVOY_BIN} --version | \
-  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9\-_]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\1/p')
+  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9_\-]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\1/p')
 
 EXPECTED=$(cat "${TEST_SRCDIR}/envoy/bazel/raw_build_id.ldscript")
 
@@ -18,7 +18,7 @@ if [[ "${COMMIT}" != "${EXPECTED}" ]]; then
 fi
 
 VERSION=$(${ENVOY_BIN} --version | \
-  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9\-_]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\2\3/p')
+  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9_\-]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\2\3/p')
 
 EXPECTED=$(cat "${TEST_SRCDIR}/envoy/VERSION")
 


### PR DESCRIPTION
#### Includes:
- update the `--version` command for the envoy static binary built by bazel to include the output of `git describe --tags --dirty --always --match 'v[0-9]*' | cut -c 2-` so that each build can be identified, e.g. `6ff52bd29029f77f131282b8578448f33f57e07f/1.21.3-6-g6ea671b2dc-dirty/Modified/DEBUG/BoringSSL`
  - The approach to set the output to a variable called `GIT_VERSION`, as described in [article](https://kchodorow.com/2017/03/27/stamping-your-builds/):
    - We leverage the `workspace_status_command` to output the key value pairing to the `bazel-out/volatile-status.txt` file, which is produced as a result of building the envoy static binary.
    - We read the variable from that file using a `genrule` in the `BUILD` file, define the constant `GIT_VERSION` in a header file called `git_version.h` that we link to the `version.cc` file, and update the `version()` function to include that constant

#### QA:
- [x] manual test of `--version` command on static binary
- [x] Running `version_out_test` shell test successfully (Note: This can be run using `bazel test //test/exe:version_out_test`)
