### PR TITLE
CLOUDP-152702: fix the regex in the version test case to only return the second group

### DIFF
--- a/test/exe/version_out_test.sh
+++ b/test/exe/version_out_test.sh
@@ -18,7 +18,7 @@ if [[ "${COMMIT}" != "${EXPECTED}" ]]; then
 fi
 
 VERSION=$(${ENVOY_BIN} --version | \
-  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9_\-]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\2\3/p')
+  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9_\-]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\2/p')
 
 EXPECTED=$(cat "${TEST_SRCDIR}/envoy/VERSION")
 


### PR DESCRIPTION
Signed-off-by: Tristan Wedderburn <tristan.wedderburn@mongodb.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: fix the regex in the version test case to only return the second group
Additional Description:
Risk Level: Low
Testing: Re-ran unit test locally
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes commit #7 
