### PR TITLE
CLOUDP-152702: Update test to check for substring in expected commit

### DIFF
--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -42,5 +42,5 @@ echo "BUILD_SCM_STATUS ${tree_status}"
 echo "STABLE_BUILD_SCM_STATUS ${tree_status}"
 
 # Generate a build version number to label built binaries in the format specified in evergreen/archive-evergreen-rhel7-amd64.sh
-git_version_number=$(git describe --tags --dirty --always --match 'v[0-9]*' | cut -c 2-)
+git_version_number=$(git describe --tags --dirty --always --match 'v[0-9]*' --abbrev=7 | cut -c 2-)
 echo "GIT_VERSION_NUMBER ${git_version_number}"

--- a/evergreen/archive-evergreen-rhel7-amd64.sh
+++ b/evergreen/archive-evergreen-rhel7-amd64.sh
@@ -9,6 +9,7 @@ cd $SRCDIR
 # an abbreviated object name for the commit. The leading "v" is then omitted.
 # --dirty: If the working tree has local modification "-dirty" is appended to it.
 # --always: Show uniquely abbreviated commit object as fallback when no tag is found.
+# --abbrev=<n>: Sets the length of the abbreviated commit object name to n.
 VERSION=$(git describe --tags --dirty --always --match 'v[0-9]*' --abbrev=7 | cut -c 2-)
 cd -
 

--- a/evergreen/archive-evergreen-rhel7-amd64.sh
+++ b/evergreen/archive-evergreen-rhel7-amd64.sh
@@ -4,7 +4,7 @@ set -xeuo pipefail
 SRCDIR=$(pwd)/src
 cd $SRCDIR
 # Generate version from the most recent base tag.
-# For example, 1.21.3-4-gdbdcfa34cf is based on the most recent tag "v1.21.3" and
+# For example, 1.21.3-4-gdbdcfa3 is based on the most recent tag "v1.21.3" and
 # has "4" commits on top of that, then it appends the "g" prefix (for git) and
 # an abbreviated object name for the commit. The leading "v" is then omitted.
 # --dirty: If the working tree has local modification "-dirty" is appended to it.
@@ -18,7 +18,7 @@ cd -
 # the docker containers cannot be accessed due to permissions, leading to a failure. Changing the
 # working directory to "ARCHIVE_PATH" is a workaround.
 ARCHIVE_PATH=archive
-# Example archive file name: envoy-serverless-1.21.3-4-gdbdcfa34cf.rhel7.amd64.tar.gz
+# Example archive file name: envoy-serverless-1.21.3-4-gdbdcfa3.rhel7.amd64.tar.gz
 ARCHIVE_DIR=envoy-serverless-${VERSION}.rhel7.amd64
 mkdir -p ${ARCHIVE_PATH}/${ARCHIVE_DIR}
 

--- a/evergreen/archive-evergreen-rhel7-amd64.sh
+++ b/evergreen/archive-evergreen-rhel7-amd64.sh
@@ -9,7 +9,7 @@ cd $SRCDIR
 # an abbreviated object name for the commit. The leading "v" is then omitted.
 # --dirty: If the working tree has local modification "-dirty" is appended to it.
 # --always: Show uniquely abbreviated commit object as fallback when no tag is found.
-VERSION=$(git describe --tags --dirty --always --match 'v[0-9]*' | cut -c 2-)
+VERSION=$(git describe --tags --dirty --always --match 'v[0-9]*' --abbrev=7 | cut -c 2-)
 cd -
 
 # The archives have to be put in a directory because evergreen s3.put will scan the working directory

--- a/test/exe/version_out_test.sh
+++ b/test/exe/version_out_test.sh
@@ -27,13 +27,12 @@ if [[ "${VERSION}" != "${EXPECTED}" ]]; then
   exit 1
 fi
 
-echo "Seen version: $(${ENVOY_BIN} --version)"
 LABEL=$(${ENVOY_BIN} --version | \
   sed -n -E "s/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-g([0-9a-f]+)(-dirty)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\4/p")
 
 EXPECTED="$(cat "${TEST_SRCDIR}/envoy/bazel/raw_build_id.ldscript")"
 
 if [[ "${EXPECTED}" != "${LABEL}"* ]]; then
-  echo "Label mismatch, got: ${LABEL}, expected: ${EXPECTED}".
+  echo "Label mismatch, expected: ${EXPECTED} to start with: ${LABEL},".
   exit 1
 fi

--- a/test/exe/version_out_test.sh
+++ b/test/exe/version_out_test.sh
@@ -27,12 +27,13 @@ if [[ "${VERSION}" != "${EXPECTED}" ]]; then
   exit 1
 fi
 
+echo "Seen version: $(${ENVOY_BIN} --version)"
 LABEL=$(${ENVOY_BIN} --version | \
-  sed -n -E "s/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-g([0-9a-f]{10})(-dirty)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\4/p")
+  sed -n -E "s/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-g([0-9a-f]+)(-dirty)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\4/p")
 
-EXPECTED="$(cat "${TEST_SRCDIR}/envoy/bazel/raw_build_id.ldscript" | head -c 10)"
+EXPECTED="$(cat "${TEST_SRCDIR}/envoy/bazel/raw_build_id.ldscript")"
 
-if [[ "${LABEL}" != "${EXPECTED}" ]]; then
+if [[ "${EXPECTED}" != "${LABEL}"* ]]; then
   echo "Label mismatch, got: ${LABEL}, expected: ${EXPECTED}".
   exit 1
 fi

--- a/test/exe/version_out_test.sh
+++ b/test/exe/version_out_test.sh
@@ -32,7 +32,8 @@ LABEL=$(${ENVOY_BIN} --version | \
 
 EXPECTED="$(cat "${TEST_SRCDIR}/envoy/bazel/raw_build_id.ldscript")"
 
+# Note: This test uses bash pattern-matching to assert that the start of EXPECTED, i.e. the commit id, matches the value of LABEL, i.e. the abbreviated object name for the commit.
 if [[ "${EXPECTED}" != "${LABEL}"* ]]; then
-  echo "Label mismatch, expected: ${EXPECTED} to start with: ${LABEL},".
+  echo "Label mismatch, expected: ${EXPECTED} to start with: ${LABEL}".
   exit 1
 fi


### PR DESCRIPTION
Signed-off-by: Tristan Wedderburn <tristan.wedderburn@mongodb.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: CLOUDP-152702: Update test to check for substring in expected commit
Additional Description:
Risk Level: Low
Testing: Updated version_out_test unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes commit #12 
