### PR TITLE
CLOUDP-155597: Delete unused import in substitution_formatter

### DIFF
--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -7,7 +7,6 @@
 #include <cstdlib>
 #include <memory>
 #include <regex>
-#include <stdexcept>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
[CLOUDP-155597](https://jira.mongodb.org/browse/CLOUDP-155597)

## Changes
Delete unused import in substitution_formatter: `<stdexcept>`

## Testing
Relevant unit tests still pass, code still compiles
