### PR TITLE
CLOUDP-173167: Update serverless-proxy version format to follow the format of envoy-serverless

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -37,6 +37,17 @@ genrule(
 )
 
 genrule(
+    name = "git_version",
+    outs = ["git_version.txt"],
+    cmd = """
+    grep GIT_VERSION bazel-out/volatile-status.txt > $@
+    """,
+    # Undocumented attr to depend on workspace status files.
+    # https://github.com/bazelbuild/bazel/issues/4942
+    stamp = 1,
+)
+
+genrule(
     name = "gnu_build_id",
     outs = ["gnu_build_id.ldscript"],
     cmd = """

--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -67,3 +67,7 @@ git_remote=$(git remote get-url origin)
 if [[ -n "$git_remote" ]]; then
     echo "BUILD_SCM_REMOTE ${git_remote}"
 fi
+
+# Generate a build version number to label built binaries in the format specified in evergreen/archive-evergreen-rhel7-amd64.sh
+git_version_number=$(git describe --tags --dirty --always --match 'v[0-9]*' | cut -c 2-)
+echo "GIT_VERSION_NUMBER ${git_version_number}"

--- a/source/common/version/BUILD
+++ b/source/common/version/BUILD
@@ -18,6 +18,23 @@ genrule(
     visibility = ["//visibility:private"],
 )
 
+# This genrule generates a header file linking GIT_VERSION_NUMBER to version.h for labeling built binaries using the workspace status command output.
+genrule(
+    name = "generate_git_version_number",
+    outs = ["git_version_number.h"],
+    cmd = """
+      grep GIT_VERSION_NUMBER bazel-out/volatile-status.txt \\
+    | sed 's/^GIT_VERSION_NUMBER //' \\
+    | tr -d '\\n' \\
+    | xargs -I{} echo "#define GIT_VERSION_NUMBER \\"{}\\"" \\
+    > $@
+    """,
+    # Undocumented attr to depend on workspace status files.
+    # https://github.com/bazelbuild/bazel/issues/4942
+    stamp = 1,
+    visibility = ["//visibility:private"],
+)
+
 genrule(
     name = "generate_api_version_number",
     srcs = ["//:API_VERSION.txt"],
@@ -47,6 +64,7 @@ envoy_cc_library(
     name = "version_includes",
     hdrs = [
         "version.h",
+        ":generate_git_version_number",
         ":generate_version_number",
     ],
     deps = [

--- a/source/common/version/version.cc
+++ b/source/common/version/version.cc
@@ -26,7 +26,7 @@ const std::string& VersionInfo::revisionStatus() {
 
 const std::string& VersionInfo::version() {
   CONSTRUCT_ON_FIRST_USE(std::string,
-                         fmt::format("{}/{}/{}/{}/{}", revision(), BUILD_VERSION_NUMBER,
+                         fmt::format("{}/{}/{}/{}/{}", revision(), GIT_VERSION_NUMBER,
                                      revisionStatus(), buildType(), sslVersion()));
 }
 

--- a/source/common/version/version.h
+++ b/source/common/version/version.h
@@ -6,6 +6,7 @@
 
 #include "source/common/singleton/const_singleton.h"
 #include "source/common/version/version_number.h"
+#include "source/common/version/git_version_number.h"
 
 namespace Envoy {
 

--- a/test/exe/BUILD
+++ b/test/exe/BUILD
@@ -54,7 +54,7 @@ envoy_sh_test(
     srcs = ["version_out_test.sh"],
     coverage = False,
     data = [
-        "//:VERSION.txt",
+        "//bazel:git_version.txt",
         "//bazel:raw_build_id.ldscript",
         "//source/exe:envoy-static",
     ],

--- a/test/exe/version_out_test.sh
+++ b/test/exe/version_out_test.sh
@@ -20,7 +20,7 @@ fi
 VERSION=$(${ENVOY_BIN} --version | \
   sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9_\-]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\2\3/p')
 
-EXPECTED=$(cat "${TEST_SRCDIR}/envoy/VERSION.txt")
+EXPECTED=$(cat "${TEST_SRCDIR}/envoy/bazel/git_versions.txt")
 
 if [[ "${VERSION}" != "${EXPECTED}" ]]; then
   echo "Version mismatch, got: ${VERSION}, expected: ${EXPECTED}".


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Created `serverless-proxy/v1.26.0` branch in envoy-serverless to track patches on top of `v1.26.0` envoy branch
Additional Description: 
Risk Level: low
Testing: Updated `version_out_test.sh`
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
