### PR TITLE
CLOUDP-183802: Create a "dummy" version to test upgrade procedure of envoy-serverless

### DIFF
--- a/evergreen/compile.sh
+++ b/evergreen/compile.sh
@@ -10,4 +10,3 @@ source $(dirname "$0")/set-up-env.sh
 # If this script can be executed, then /etc/envoy-serverless must be accessable.
 cd /etc/envoy-serverless
 bazel ${bazel_startup_flags} build ${bazel_flags} -- //:envoy
-


### PR DESCRIPTION
[CLOUDP-183802](https://jira.mongodb.org/browse/CLOUDP-183802)

## Changes 
- This PR deletes an unneeded newline and introduces no substantial changes. The purpose of this PR is to make an "empty" commit to the `envoy-serverless` repo to trigger a new build with "identical" binary to the code currently running for serverless envoys so that we can test the upgrade procedure before changing the binary. 