### PR TITLE
CLOUDP-185600: Disabling tcp_stats in envoy-serverless should reference the repo name

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -47,7 +47,7 @@ build --incompatible_enforce_config_setting_visibility
 test --test_verbose_timeout_warnings
 
 # The TCP/IP implementation in CentOS 7 doesn't support RFC4898: TCP Extended Statistics MIB, which leads to compilation failures.
-build --//source/extensions/transport_sockets/tcp_stats:enabled=false
+build --@envoy//source/extensions/transport_sockets/tcp_stats:enabled=false
 
 # Allow tags to influence execution requirements
 common --experimental_allow_tags_propagation


### PR DESCRIPTION
[CLOUDP-185600](https://jira.mongodb.org/browse/CLOUDP-185600)
