### PR TITLE
CLOUDP-197792: Modify serverless proxy version string to ease backports

### DIFF
--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -70,4 +70,11 @@ fi
 
 # Generate a build version number to label built binaries in the format specified in evergreen scripts
 git_version_number=$(git describe --tags --dirty --always --match 'v[0-9]*' --abbrev=7 | cut -c 2-)
+
+# If this RELEASE_VERSION file exists then include it in the git version number used to label built binaries
+if [ -f RELEASE_VERSION ]; then
+    release_version=$(cat RELEASE_VERSION)
+    git_version_number="${release_version}-${git_version_number}"
+fi
+
 echo "GIT_VERSION_NUMBER ${git_version_number}"

--- a/test/exe/version_out_test.sh
+++ b/test/exe/version_out_test.sh
@@ -8,7 +8,7 @@ export LC_ALL=C
 ENVOY_BIN="${TEST_SRCDIR}/envoy/source/exe/envoy-static"
 
 COMMIT=$(${ENVOY_BIN} --version | \
-  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9_\-]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\1/p')
+  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+-)?([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9_\-]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\1/p')
 
 EXPECTED=$(cat "${TEST_SRCDIR}/envoy/bazel/raw_build_id.ldscript")
 
@@ -18,7 +18,7 @@ if [[ "${COMMIT}" != "${EXPECTED}" ]]; then
 fi
 
 VERSION=$(${ENVOY_BIN} --version | \
-  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9_\-]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\2\3/p')
+  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+-)?([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9_\-]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\3\4/p')
 
 EXPECTED=$(cat "${TEST_SRCDIR}/envoy/bazel/git_version.txt")
 


### PR DESCRIPTION
[CLOUDP-197792](https://jira.mongodb.org/browse/CLOUDP-197792)

New version: `20240104-1.26.3-28-g5f08fc3`

#### Includes:
- add optional release version input from `RELEASE_VERSION` file

#### QA:
- update regex for unit tests