### PR TITLE
CLOUDP-222331: Update envoy workspace status command for --version output

### DIFF
--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -74,8 +74,8 @@ git_version_number=$(git describe --tags --dirty --always --match 'v[0-9]*' --ab
 root_dir="$(git rev-parse --show-toplevel)"
 
 # If this RELEASE_VERSION file exists then include it in the version used to label built binaries
-if [ -f "${root_dir}/bazel/RELEASE_VERSION" ]; then
-    release_version_prefix=$(cat "${root_dir}/bazel/RELEASE_VERSION")
+if [ -f "${root_dir}/RELEASE_VERSION" ]; then
+    release_version_prefix=$(cat "${root_dir}/RELEASE_VERSION")
     git_version_number="${release_version_prefix}-${git_version_number}"
 fi
 

--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -71,10 +71,12 @@ fi
 # Generate a build version number to label built binaries in the format specified in evergreen scripts
 git_version_number=$(git describe --tags --dirty --always --match 'v[0-9]*' --abbrev=7 | cut -c 2-)
 
-# If this RELEASE_VERSION file exists then include it in the git version number used to label built binaries
-if [ -f RELEASE_VERSION ]; then
-    release_version=$(cat RELEASE_VERSION)
-    git_version_number="${release_version}-${git_version_number}"
+root_dir="$(git rev-parse --show-toplevel)"
+
+# If this RELEASE_VERSION file exists then include it in the version used to label built binaries
+if [ -f "${root_dir}/bazel/RELEASE_VERSION" ]; then
+    release_version_prefix=$(cat "${root_dir}/bazel/RELEASE_VERSION")
+    git_version_number="${release_version_prefix}-${git_version_number}"
 fi
 
 echo "GIT_VERSION_NUMBER ${git_version_number}"


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

____

[CLOUDP-222331](https://jira.mongodb.org/browse/CLOUDP-222331)

# Includes:
- update workspace status command file to look for `RELEASE_VERSION` script in the root of the git repo, as seen in the serverless-proxy archive script

# QA:
- [x] manual test 