### PR TITLE
CLOUDP-216728 fix requires insecure repo to build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ ENV BUILD_DIR=/build
 ENV ENVOY_STDLIB=libstdc++
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -y update \
+RUN apt-get -y update --allow-insecure-repositories \
   && apt-get -y install --no-install-recommends libpython2.7 net-tools psmisc vim 2>&1 \
   # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
   && groupadd --gid $USER_GID $USERNAME \


### PR DESCRIPTION
the current devcontainer requires an insecure repo to build we would ignore this error by passing this flag. I haven't investigated the level of effort to remove the insecure repo from our build. would we prefer to close this security hole? or open one?