### PR TITLE
CLOUDP-223402: Failed Task: serverless-proxy-envoy_test/al2-aarch64

### DIFF
--- a/test/exe/version_out_test.sh
+++ b/test/exe/version_out_test.sh
@@ -18,7 +18,7 @@ if [[ "${COMMIT}" != "${EXPECTED}" ]]; then
 fi
 
 VERSION=$(${ENVOY_BIN} --version | \
-  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+-)?([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9_\-]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\3\4/p')
+  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+-)?([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9_\-]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\2\3\4/p')
 
 EXPECTED=$(cat "${TEST_SRCDIR}/envoy/bazel/git_version.txt")
 

--- a/test/exe/version_out_test.sh
+++ b/test/exe/version_out_test.sh
@@ -7,6 +7,17 @@ export LC_ALL=C
 
 ENVOY_BIN="${TEST_SRCDIR}/envoy/source/exe/envoy-static"
 
+# Note: The output of the --version command differs based on the presence of a RELEASE_VERSION file during bazel workspace status generation.
+# If the file is present, the --version command output will include the content of the file as a prefix to the text after the first '/'.
+# For example:
+# bazel-bin/envoy  version: 2f7ac770075de46ce960f4da95b40bd49834dcb1/20240104-1.26.3-65-g2f7ac77/Modified/DEBUG/BoringSSL
+# where 20240104 is taken from the RELEASE_VERSION file.
+# If RELEASE_VERSION was not present, the --version command output would be:
+# bazel-bin/envoy  version: 2f7ac770075de46ce960f4da95b40bd49834dcb1/1.26.3-65-g2f7ac77/Modified/DEBUG/BoringSSL
+# This prefix is optionally captured by the second regex capture group below.
+
+# Example expected COMMIT: 2f7ac770075de46ce960f4da95b40bd49834dcb1
+
 COMMIT=$(${ENVOY_BIN} --version | \
   sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+-)?([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9_\-]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\1/p')
 
@@ -16,6 +27,8 @@ if [[ "${COMMIT}" != "${EXPECTED}" ]]; then
   echo "Commit mismatch, got: ${COMMIT}, expected: ${EXPECTED}".
   exit 1
 fi
+
+# Example expected VERSION: 20240104-1.26.3-65-g2f7ac77
 
 VERSION=$(${ENVOY_BIN} --version | \
   sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+-)?([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9_\-]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\2\3\4/p')


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

---
[CLOUDP-223402](https://jira.mongodb.org/browse/CLOUDP-223402)

#### Includes:
- fix `version_out_test.sh` to include the release version prefix, i.e. the 2nd regex capture group

#### QA:
- [x] manual test adding a `RELEASE_VERSION` file in serverless-proxy and making the same change in the submodule

Initial failed test error w/ added log line:

<img width="690" alt="Screenshot 2024-01-19 at 10 35 32 AM" src="https://github.com/10gen/envoy-serverless/assets/20159234/d5bfbf3d-d473-4032-b954-0656b7993203">

After change:

<img width="572" alt="Screenshot 2024-01-19 at 10 36 02 AM" src="https://github.com/10gen/envoy-serverless/assets/20159234/1bffc5ec-1745-4e1d-93e2-3d13d6beb30e">
