### PR TITLE
Ensure gRPC client outlives owned streams

### DIFF
--- a/source/common/grpc/async_client_impl.h
+++ b/source/common/grpc/async_client_impl.h
@@ -55,11 +55,15 @@ class CallbackHolder {
 public:
   typedef std::unique_ptr<RawAsyncStreamCallbacks> CallbackPtr;
   CallbackPtr& getHeldCallback() { return callback_; }
-  void setHeldCallback(CallbackPtr&& callback) { callback_ = std::move(callback); }
+  void setHeldCallback(CallbackPtr&& callback, RawAsyncClientSharedPtr client = nullptr) {
+    callback_ = std::move(callback);
+    client_ = client;
+  }
 
 protected:
   CallbackHolder() = default;
   CallbackPtr callback_;
+  RawAsyncClientSharedPtr client_;
 };
 
 class AsyncStreamImpl : public RawAsyncStream,


### PR DESCRIPTION
# [CLOUDP-234911](https://jira.mongodb.org/browse/CLOUDP-234911)

This PR adds a shared pointer to the parent client for a stream as part of the callback holder scheme used to extend the lifetime of a stream beyond the lifetime of the downstream connection/filter instance. It does this by allowing one to also set a client shared pointer on the callback holder for a stream. In this way the client can be removed from the cache after the default 50 seconds and, when the last filter instance holding a reference to the client is destroyed as part of the downstream connection closing, the client will not be immediately destroyed itself. Instead, a reference is held on the stream/callback holder, so after the stream that we open to send the remove connection id command is finished, the client will place it on the deferred deletion list and, when the dispatcher makes a sweep and deletes the stream, the parent client's ref count will be decremented and the client itself will be destroyed.

This avoids the race where the client is destroyed after the filter instance is destroyed and the streams it owns (like the remove connection id stream) are placed on the deferred list, giving the dispatcher a chance to destroy them (reset) before the upstream has a chance to process and respond to the request.

To test, I modified `serverless proxy` to set the client along with the callback holder when we send remove connection id:
```
diff --git a/source/extensions/filters/network/mongorpc_grpc_transcode/client_impl.cc b/source/extensions/filters/network/mongorpc_grpc_transcode/client_impl.cc
index ebf374d972..94dd9847e9 100644
--- a/source/extensions/filters/network/mongorpc_grpc_transcode/client_impl.cc
+++ b/source/extensions/filters/network/mongorpc_grpc_transcode/client_impl.cc
@@ -656,7 +656,8 @@ void ClientImpl::sendRemoveConnectionId(const Protocol& protocol,

   if (bye_stream != nullptr) {
     // Store the callback in the stream so that it is not destroyed before the stream is.
-    dynamic_cast<Envoy::Grpc::CallbackHolder*>(bye_stream)->setHeldCallback(std::move(callback));
+    dynamic_cast<Envoy::Grpc::CallbackHolder*>(bye_stream)
+        ->setHeldCallback(std::move(callback), async_client_);

     bye_stream->sendMessageRaw(std::move(bye_buffer), true);
   } else {
```

I then set up `tc` to delay traffic:
```
  # the prio map is setting band 0 for all TOS types, i.e., all traffic is treated as highest priority (interactive)
  # traffic will be sent to 1:1 by default here
  # minor numbers represent bands. their value is 1 + the band, so 1:2 is the root qdisc handle or major (1) and the band or minor(2) for band 1
  sudo tc qdisc add dev lo root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0

  # configure one of the other bands to delay traffic, note this should not be hit given the priomap we set above
  sudo tc qdisc add dev lo parent 1:2 handle 20: netem delay 200ms

  # add a filter to redirect matching traffic to band 1 (minor 2), where delay is introduced
  sudo tc filter add dev lo parent 1: protocol ip u32 match ip dport 9901 0xffff flowid 1:2
  sudo tc filter add dev lo parent 1: protocol ip u32 match ip dport 9911 0xffff flowid 1:2
  sudo tc filter add dev lo parent 1: protocol ip u32 match ip dport 9921 0xffff flowid 1:2
```

You can then use `mongosh` or something else to open a connection, issue a command, wait long than 50 seconds, then close the connections. Without the above changes, you should reliably see connections leak in atlas proxy:
```
[2024/03/04 21:42:58.262] [ProxySession(63b1135000000000000000e1_,host.local.10gen.cc,127.0.0.1:49826,4a845154-b85b-47cf-a5f4-a5ac15d4921a).info] [session_factory.go:processUnknownSecurityUUID:528] new gRPC proxy session to host.local.10gen.cc (DBPrefix 63b1135000000000000000e1_) with 1 connections now open
[2024/03/04 21:42:59.523] [ProxySession(63b1135000000000000000e1_,host.local.10gen.cc,127.0.0.1:49840,e01b9c43-7b89-4fae-b6e4-39115363f7c4).info] [session_factory.go:processUnknownSecurityUUID:528] new gRPC proxy session to host.local.10gen.cc (DBPrefix 63b1135000000000000000e1_) with 2 connections now open
[2024/03/04 21:42:59.536] [ProxySession(63b1135000000000000000e1_,host.local.10gen.cc,127.0.0.1:49836,8c6d9262-36dd-4579-a7d0-0654c2fef446).info] [session_factory.go:processUnknownSecurityUUID:528] new gRPC proxy session to host.local.10gen.cc (DBPrefix 63b1135000000000000000e1_) with 3 connections now open
[2024/03/04 21:46:32.958] [ProxySession(63b1135000000000000000e1_,host.local.10gen.cc,127.0.0.1:49836,).info] [commands_atlas.go:func1:376] removeConnectionId command executed. Closing connection for account sni host.local.10gen.cc open connections= 2
[2024/03/04 21:46:32.959] [ProxySession(63b1135000000000000000e1_,host.local.10gen.cc,127.0.0.1:49840,).info] [commands_atlas.go:func1:376] removeConnectionId command executed. Closing connection for account sni host.local.10gen.cc open connections= 1
[2024/03/04 21:47:01.794] [ProxySession(63b1135000000000000000e1_,host.local.10gen.cc,127.0.0.1:55376,26d6c1ed-3d48-4a19-9cd8-cfb4fe45077b).info] [session_factory.go:processUnknownSecurityUUID:528] new gRPC proxy session to host.local.10gen.cc (DBPrefix 63b1135000000000000000e1_) with 2 connections now open
[2024/03/04 21:47:03.055] [ProxySession(63b1135000000000000000e1_,host.local.10gen.cc,127.0.0.1:50854,ac234ce5-b7f5-4f28-8e78-c92f96607bf2).info] [session_factory.go:processUnknownSecurityUUID:528] new gRPC proxy session to host.local.10gen.cc (DBPrefix 63b1135000000000000000e1_) with 3 connections now open
[2024/03/04 21:47:03.055] [ProxySession(63b1135000000000000000e1_,host.local.10gen.cc,127.0.0.1:50856,850e6c42-01c6-43e0-969a-28c88f3bf97b).info] [session_factory.go:processUnknownSecurityUUID:528] new gRPC proxy session to host.local.10gen.cc (DBPrefix 63b1135000000000000000e1_) with 4 connections now open
[2024/03/04 21:47:04.855] [ProxySession(63b1135000000000000000e1_,host.local.10gen.cc,127.0.0.1:50854,).info] [commands_atlas.go:func1:376] removeConnectionId command executed. Closing connection for account sni host.local.10gen.cc open connections= 3
[2024/03/04 21:47:04.855] [ProxySession(63b1135000000000000000e1_,host.local.10gen.cc,127.0.0.1:50856,).info] [commands_atlas.go:func1:376] removeConnectionId command executed. Closing connection for account sni host.local.10gen.cc open connections= 2
[2024/03/04 21:47:04.856] [ProxySession(63b1135000000000000000e1_,host.local.10gen.cc,127.0.0.1:55376,).info] [commands_atlas.go:func1:376] removeConnectionId command executed. Closing connection for account sni host.local.10gen.cc open connections= 1
```

# QA performed
- [x] manual testing