### PR TITLE
CLOUDP-236550: v1.29.2 rebase for pass through TLVs as HTTP headers

### DIFF
--- a/source/common/formatter/BUILD
+++ b/source/common/formatter/BUILD
@@ -35,6 +35,7 @@ envoy_cc_library(
         "//source/common/grpc:common_lib",
         "//source/common/http:utility_lib",
         "//source/common/json:json_loader_lib",
+        "//source/common/network:proxy_protocol_filter_state_lib",
         "//source/common/protobuf:message_validator_lib",
         "//source/common/runtime:runtime_features_lib",
         "//source/common/stream_info:utility_lib",

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -451,11 +451,12 @@ ProxyProtocolTlvsFormatter::ProxyProtocolTlvsFormatter(const std::string& tlv_ty
   }
 }
 
-absl::optional<std::string> ProxyProtocolTlvsFormatter::format(const StreamInfo::StreamInfo& stream_info) const {
+absl::optional<std::string>
+ProxyProtocolTlvsFormatter::format(const StreamInfo::StreamInfo& stream_info) const {
   const auto& typed_state =
       stream_info.filterState().getDataReadOnly<Network::ProxyProtocolFilterState>(
           Network::ProxyProtocolFilterState::key());
-  
+
   // ProxyProtocolFilterState is not stored in the filter state.
   if (typed_state == nullptr) {
     ENVOY_LOG_MISC(debug, "Invalid header: PROXY_PROTOCOL_TLVS. The ProxyProtocolFilterState is "
@@ -480,7 +481,8 @@ absl::optional<std::string> ProxyProtocolTlvsFormatter::format(const StreamInfo:
   return oss.str();
 }
 
-ProtobufWkt::Value ProxyProtocolTlvsFormatter::formatValue(const StreamInfo::StreamInfo& stream_info) const {
+ProtobufWkt::Value
+ProxyProtocolTlvsFormatter::formatValue(const StreamInfo::StreamInfo& stream_info) const {
   return ValueUtil::optionalStringValue(format(stream_info));
 }
 

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -2,8 +2,10 @@
 
 #include <regex>
 
+#include "source/common/common/base64.h"
 #include "source/common/config/metadata.h"
 #include "source/common/http/utility.h"
+#include "source/common/network/proxy_protocol_filter_state.h"
 #include "source/common/runtime/runtime_features.h"
 #include "source/common/stream_info/utility.h"
 
@@ -432,6 +434,55 @@ public:
 private:
   FieldExtractor field_extractor_;
 };
+
+ProxyProtocolTlvsFormatter::ProxyProtocolTlvsFormatter(const std::string& tlv_type_str) {
+  // Specified tlv_type must be parsable as an int.
+  if (!absl::SimpleAtoi(tlv_type_str, &tlv_type_)) {
+    throw EnvoyException(fmt::format(
+        "Invalid parameter provided for PROXY_PROTOCOL_TLVS header: {}. Not parsable as int.",
+        tlv_type_str));
+  }
+
+  // Check if a valid TLV type was passed in.
+  if (tlv_type_ >= 256 || tlv_type_ <= 0) {
+    throw EnvoyException(fmt::format("Invalid parameter provided for PROXY_PROTOCOL_TLVS header: "
+                                     "{}. Must be a positive integer less than 256.",
+                                     tlv_type_str));
+  }
+}
+
+absl::optional<std::string> ProxyProtocolTlvsFormatter::format(const StreamInfo::StreamInfo& stream_info) const {
+  const auto& typed_state =
+      stream_info.filterState().getDataReadOnly<Network::ProxyProtocolFilterState>(
+          Network::ProxyProtocolFilterState::key());
+  
+  // ProxyProtocolFilterState is not stored in the filter state.
+  if (typed_state == nullptr) {
+    ENVOY_LOG_MISC(debug, "Invalid header: PROXY_PROTOCOL_TLVS. The ProxyProtocolFilterState is "
+                          "not stored in the filter state.");
+    return absl::nullopt;
+  }
+
+  std::ostringstream oss;
+  int match_count = 0;
+  for (auto& tlv : typed_state->value().tlv_vector_) {
+    if (tlv.type == tlv_type_) {
+      if (match_count > 0)
+        oss << ", ";
+      oss << Base64::encode(reinterpret_cast<const char*>(tlv.value.data()), tlv.value.size());
+      match_count++;
+    }
+  }
+  ENVOY_LOG_MISC(
+      debug,
+      "Formatting PROXY_PROTOCOL_TLVS header: {} TLVs are stored. {} with type {} added to header.",
+      typed_state->value().tlv_vector_.size(), match_count, tlv_type_);
+  return oss.str();
+}
+
+ProtobufWkt::Value ProxyProtocolTlvsFormatter::formatValue(const StreamInfo::StreamInfo& stream_info) const {
+  return ValueUtil::optionalStringValue(format(stream_info));
+}
 
 // StreamInfo std::chrono_nanoseconds field extractor.
 class StreamInfoDurationFormatterProvider : public StreamInfoFormatterProvider {
@@ -1412,6 +1463,11 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
            {CommandSyntaxChecker::PARAMS_OPTIONAL | CommandSyntaxChecker::LENGTH_ALLOWED,
             [](const std::string& format, absl::optional<size_t> max_length) {
               return FilterStateFormatter::create(format, max_length, true);
+            }}},
+          {"PROXY_PROTOCOL_TLVS",
+           {CommandSyntaxChecker::PARAMS_REQUIRED,
+            [](const std::string& tlv_type, const absl::optional<size_t>) {
+              return std::make_unique<ProxyProtocolTlvsFormatter>(tlv_type);
             }}},
           {"DOWNSTREAM_PEER_CERT_V_START",
            {CommandSyntaxChecker::PARAMS_OPTIONAL,

--- a/source/common/formatter/stream_info_formatter.h
+++ b/source/common/formatter/stream_info_formatter.h
@@ -119,6 +119,21 @@ private:
 };
 
 /**
+ * StreamInfoFormatterProvider for ProxyProtocolTlvs stored in FilterState from StreamInfo.
+ */
+class ProxyProtocolTlvsFormatter : public StreamInfoFormatterProvider {
+public:
+  ProxyProtocolTlvsFormatter(const std::string& tlv_type);
+  // StreamInfoFormatterProvider
+  absl::optional<std::string> format(const StreamInfo::StreamInfo&) const override;
+  
+  ProtobufWkt::Value formatValue(const StreamInfo::StreamInfo&) const override;
+
+private:
+  int tlv_type_;
+};
+
+/**
  * Base StreamInfoFormatterProvider for system times from StreamInfo.
  */
 class SystemTimeFormatter : public StreamInfoFormatterProvider {

--- a/source/common/formatter/stream_info_formatter.h
+++ b/source/common/formatter/stream_info_formatter.h
@@ -126,7 +126,7 @@ public:
   ProxyProtocolTlvsFormatter(const std::string& tlv_type);
   // StreamInfoFormatterProvider
   absl::optional<std::string> format(const StreamInfo::StreamInfo&) const override;
-  
+
   ProtobufWkt::Value formatValue(const StreamInfo::StreamInfo&) const override;
 
 private:

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -15,6 +15,7 @@
 #include "source/common/http/header_map_impl.h"
 #include "source/common/json/json_loader.h"
 #include "source/common/network/address_impl.h"
+#include "source/common/network/proxy_protocol_filter_state.h"
 #include "source/common/protobuf/utility.h"
 #include "source/common/router/string_accessor_impl.h"
 #include "source/common/stream_info/stream_id_provider_impl.h"
@@ -2131,6 +2132,98 @@ TEST(SubstitutionFormatterTest, FilterStateFormatter) {
 
     EXPECT_EQ("test_", formatter.format(stream_info));
     EXPECT_THAT(formatter.formatValue(stream_info), ProtoEq(ValueUtil::stringValue("test_")));
+  }
+}
+
+TEST(SubstitutionFormatterTest, ProxyProtocolTlvsFormatter) {
+  auto src_addr =
+      Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("1.2.3.4", 773));
+  auto dst_addr =
+      Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("0.1.1.2", 513));
+    
+  // No parameter value passed in for tlv_type.
+  {
+    EXPECT_THROW_WITH_MESSAGE(SubstitutionFormatParser::parse("%PROXY_PROTOCOL_TLVS()%"),
+                              EnvoyException, "PROXY_PROTOCOL_TLVS requires parameters");
+  }
+
+  // Invalid tlv_type passed as parameter -- non-integer
+  {
+    EXPECT_THROW_WITH_MESSAGE(
+        SubstitutionFormatParser::parse("%PROXY_PROTOCOL_TLVS(INVALID_TLV_TYPE)%"), EnvoyException,
+        "Invalid parameter provided for PROXY_PROTOCOL_TLVS header: INVALID_TLV_TYPE. Not parsable "
+        "as int.");
+  }
+
+  // Invalid tlv_type passed as parameter -- too large of a number for stoi to parse as int
+  {
+    EXPECT_THROW_WITH_MESSAGE(SubstitutionFormatParser::parse("%PROXY_PROTOCOL_TLVS(3000000000)%"),
+                              EnvoyException,
+                              "Invalid parameter provided for PROXY_PROTOCOL_TLVS header: "
+                              "3000000000. Not parsable as int.");
+  }
+
+  // Invalid tlv_type passed as parameter -- too large of a number to be a valid TLV type
+  {
+    EXPECT_THROW_WITH_MESSAGE(SubstitutionFormatParser::parse("%PROXY_PROTOCOL_TLVS(300)%"),
+                              EnvoyException,
+                              "Invalid parameter provided for PROXY_PROTOCOL_TLVS header: 300. "
+                              "Must be a positive integer less than 256.");
+  }
+
+  // ProxyProtocolFilterState is not stored in FilterState
+  {
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
+    EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
+    auto providers = SubstitutionFormatParser::parse("%PROXY_PROTOCOL_TLVS(2)%");
+    ASSERT_EQ(providers.size(), 1);
+    EXPECT_EQ(absl::nullopt, providers[0]->formatWithContext({}, stream_info));
+  }
+
+  // No TLVs stored in FilterState with specified tlv_type
+  {
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
+    Network::ProxyProtocolTLV tlv{0x5, {'1'}};
+    Network::ProxyProtocolData proxy_proto_data{src_addr, dst_addr, {tlv}};
+    stream_info.filter_state_->setData(
+        Network::ProxyProtocolFilterState::key(),
+        std::make_unique<Network::ProxyProtocolFilterState>(proxy_proto_data),
+        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+    EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
+    auto providers = SubstitutionFormatParser::parse("%PROXY_PROTOCOL_TLVS(2)%");
+    ASSERT_EQ(providers.size(), 1);
+    EXPECT_EQ("", providers[0]->formatWithContext({}, stream_info));
+  }
+
+  // Success case - only 1 TLV value of the associated type stored in the filter state
+  {
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
+    Network::ProxyProtocolTLV tlv_one{0x5, {'\6', '\7'}};
+    Network::ProxyProtocolData proxy_proto_data{src_addr, dst_addr, {tlv_one}};
+    stream_info.filter_state_->setData(
+        Network::ProxyProtocolFilterState::key(),
+        std::make_unique<Network::ProxyProtocolFilterState>(proxy_proto_data),
+        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+    auto providers = SubstitutionFormatParser::parse("%PROXY_PROTOCOL_TLVS(5)%");
+    ASSERT_EQ(providers.size(), 1);
+    EXPECT_EQ("Bgc=", providers[0]->formatWithContext({}, stream_info));
+  }
+
+  // Success case - 2 TLV values of the associated type stored in the filter state, 1 TLV value with
+  // different type stored
+  {
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
+    Network::ProxyProtocolTLV tlv_one{0x5, {'\6', '\7'}};
+    Network::ProxyProtocolTLV tlv_two{0x5, {'\6', '\4'}};
+    Network::ProxyProtocolTLV tlv_three{0x2, {'\6', '\3'}};
+    Network::ProxyProtocolData proxy_proto_data{src_addr, dst_addr, {tlv_one, tlv_two, tlv_three}};
+    stream_info.filter_state_->setData(
+        "envoy.network.proxy_protocol_options",
+        std::make_unique<Network::ProxyProtocolFilterState>(proxy_proto_data),
+        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+    auto providers = SubstitutionFormatParser::parse("%PROXY_PROTOCOL_TLVS(5)%");
+    ASSERT_EQ(providers.size(), 1);
+    EXPECT_EQ("Bgc=, BgQ=", providers[0]->formatWithContext({}, stream_info));
   }
 }
 

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -2140,7 +2140,7 @@ TEST(SubstitutionFormatterTest, ProxyProtocolTlvsFormatter) {
       Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("1.2.3.4", 773));
   auto dst_addr =
       Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("0.1.1.2", 513));
-    
+
   // No parameter value passed in for tlv_type.
   {
     EXPECT_THROW_WITH_MESSAGE(SubstitutionFormatParser::parse("%PROXY_PROTOCOL_TLVS()%"),


### PR DESCRIPTION
[CLOUDP-236550](https://jira.mongodb.org/browse/CLOUDP-236550)
 
This PR contains the v1.29.2 rebase of the pass through TLVs as HTTP headers changes for SRE. It is not meant to merged in this repo. 