### PR TITLE
Ignore "external" symlink in repo root to help support clangd in serverless proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ lerna-debug.log*
 node_modules
 dist
 *.bak
+
+# clangd support for serverless proxy
+/external


### PR DESCRIPTION
This is necessary to support the changes to `refresh_compdb.sh` in the serverless proxy repo [here](https://github.com/10gen/serverless-proxy/pull/288/files#diff-5bc3e76542cf6d4ea1899412f89c9afcf5f20f75dbdd4335feef3117df8b5d1bR61).